### PR TITLE
Limiting the spinOnce() loop.

### DIFF
--- a/src/cbf_coverage.cpp
+++ b/src/cbf_coverage.cpp
@@ -2021,20 +2021,8 @@ int main(int argc, char **argv)
 
     // rclcpp::sleep_for(100000000ns);
     // rclcpp::shutdown();
-    ros::Duration sleeper(0.01);
 
-    while(!node_shutdown_request)
-    {
-        ros::spinOnce();
-        sleeper.sleep();
-    }
-    node->stop();
-
-    if (ros::ok())
-    {
-        ROS_WARN("ROS HAS NOT BEEN PROPERLY SHUTDOWN, it is being shutdown again.");
-        ros::shutdown();
-    }
+    ros::spin();
 
     return 0;
 }

--- a/src/cbf_coverage.cpp
+++ b/src/cbf_coverage.cpp
@@ -2021,10 +2021,12 @@ int main(int argc, char **argv)
 
     // rclcpp::sleep_for(100000000ns);
     // rclcpp::shutdown();
+    ros::Duration sleeper(0.01);
 
     while(!node_shutdown_request)
     {
         ros::spinOnce();
+        sleeper.sleep();
     }
     node->stop();
 

--- a/src/mrs_pf_coverage.cpp
+++ b/src/mrs_pf_coverage.cpp
@@ -2069,10 +2069,12 @@ int main(int argc, char **argv)
 
     // rclcpp::sleep_for(100000000ns);
     // rclcpp::shutdown();
+    ros::Duration sleeper(0.01);
 
     while(!node_shutdown_request)
     {
         ros::spinOnce();
+        sleeper.sleep();
     }
     node->stop();
 

--- a/src/mrs_pf_coverage.cpp
+++ b/src/mrs_pf_coverage.cpp
@@ -2069,20 +2069,8 @@ int main(int argc, char **argv)
 
     // rclcpp::sleep_for(100000000ns);
     // rclcpp::shutdown();
-    ros::Duration sleeper(0.01);
 
-    while(!node_shutdown_request)
-    {
-        ros::spinOnce();
-        sleeper.sleep();
-    }
-    node->stop();
-
-    if (ros::ok())
-    {
-        ROS_WARN("ROS HAS NOT BEEN PROPERLY SHUTDOWN, it is being shutdown again.");
-        ros::shutdown();
-    }
+    ros::spin();
 
     return 0;
 }

--- a/src/mrs_pf_coverage2.cpp
+++ b/src/mrs_pf_coverage2.cpp
@@ -1617,20 +1617,8 @@ int main(int argc, char **argv)
 
     // rclcpp::sleep_for(100000000ns);
     // rclcpp::shutdown();
-    ros::Duration sleeper(0.01);
 
-    while (!node_shutdown_request)
-    {
-        ros::spinOnce();
-        sleeper.sleep();
-    }
-    node->stop();
-
-    if (ros::ok())
-    {
-        ROS_WARN("ROS HAS NOT BEEN PROPERLY SHUTDOWN, it is being shutdown again.");
-        ros::shutdown();
-    }
+    ros::spin();
 
     return 0;
 }

--- a/src/mrs_pf_coverage2.cpp
+++ b/src/mrs_pf_coverage2.cpp
@@ -1617,10 +1617,12 @@ int main(int argc, char **argv)
 
     // rclcpp::sleep_for(100000000ns);
     // rclcpp::shutdown();
+    ros::Duration sleeper(0.01);
 
     while (!node_shutdown_request)
     {
         ros::spinOnce();
+        sleeper.sleep();
     }
     node->stop();
 

--- a/src/mrs_test.cpp
+++ b/src/mrs_test.cpp
@@ -1613,9 +1613,12 @@ int main(int argc, char **argv)
     // rclcpp::sleep_for(100000000ns);
     // rclcpp::shutdown();
 
+    ros::Duration sleeper(0.01);
+
     while (!node_shutdown_request)
     {
         ros::spinOnce();
+        sleeper.sleep();
     }
     node->stop();
 

--- a/src/mrs_test.cpp
+++ b/src/mrs_test.cpp
@@ -1613,20 +1613,7 @@ int main(int argc, char **argv)
     // rclcpp::sleep_for(100000000ns);
     // rclcpp::shutdown();
 
-    ros::Duration sleeper(0.01);
-
-    while (!node_shutdown_request)
-    {
-        ros::spinOnce();
-        sleeper.sleep();
-    }
-    node->stop();
-
-    if (ros::ok())
-    {
-        ROS_WARN("ROS HAS NOT BEEN PROPERLY SHUTDOWN, it is being shutdown again.");
-        ros::shutdown();
-    }
+    ros::spin();
 
     return 0;
 }

--- a/src/starting_pos.cpp
+++ b/src/starting_pos.cpp
@@ -213,10 +213,12 @@ int main(int argc, char **argv)
 
     // rclcpp::sleep_for(100000000ns);
     // rclcpp::shutdown();
+    ros::Duration sleeper(0.01);
 
     while(!node_shutdown_request)
     {
         ros::spinOnce();
+        sleeper.sleep();
     }
     node->stop();
 

--- a/src/starting_pos.cpp
+++ b/src/starting_pos.cpp
@@ -213,20 +213,8 @@ int main(int argc, char **argv)
 
     // rclcpp::sleep_for(100000000ns);
     // rclcpp::shutdown();
-    ros::Duration sleeper(0.01);
 
-    while(!node_shutdown_request)
-    {
-        ros::spinOnce();
-        sleeper.sleep();
-    }
-    node->stop();
-
-    if (ros::ok())
-    {
-        ROS_WARN("ROS HAS NOT BEEN PROPERLY SHUTDOWN, it is being shutdown again.");
-        ros::shutdown();
-    }
+    ros::spin();
 
     return 0;
 }

--- a/src/vision_sim.cpp
+++ b/src/vision_sim.cpp
@@ -346,20 +346,8 @@ int main(int argc, char **argv)
 
     // rclcpp::sleep_for(100000000ns);
     // rclcpp::shutdown();
-    ros::Duration sleeper(0.01);
 
-    while(!node_shutdown_request)
-    {
-        ros::spinOnce();
-        sleeper.sleep();
-    }
-    node->stop();
-
-    if (ros::ok())
-    {
-        ROS_WARN("ROS HAS NOT BEEN PROPERLY SHUTDOWN, it is being shutdown again.");
-        ros::shutdown();
-    }
+    ros::spin();
 
     return 0;
 }

--- a/src/vision_sim.cpp
+++ b/src/vision_sim.cpp
@@ -346,10 +346,12 @@ int main(int argc, char **argv)
 
     // rclcpp::sleep_for(100000000ns);
     // rclcpp::shutdown();
+    ros::Duration sleeper(0.01);
 
     while(!node_shutdown_request)
     {
         ros::spinOnce();
+        sleeper.sleep();
     }
     node->stop();
 


### PR DESCRIPTION
Before, there were unlimited loops with `ros::spinOnce()`. Since these are not limited in any way,  each instance of such program was taking an entire thread of the processor by iterating in the loop at maximum possible rate. There should at least have been sleeps inside the loop. I have changed it to the standard `ros::sleep()` command which has limits inside.